### PR TITLE
fix: error build on Swift 5.10

### DIFF
--- a/Sources/BazelPodsCore/Core/MultiPlatform.swift
+++ b/Sources/BazelPodsCore/Core/MultiPlatform.swift
@@ -105,12 +105,14 @@ struct MultiPlatform<T: AttrSetConstraint>: Monoid, StarlarkConvertible, EmptyAw
     func toStarlark() -> StarlarkNode {
         precondition(ios != nil || osx != nil || watchos != nil || tvos != nil, "MultiPlatform empty can't be rendered")
 
+        // TODO: Change to T.empty and move ios up when we support other platforms
+        let iosSupport = [SelectCase.fallback.rawValue: ios ?? T.empty]
+
         return .functionCall(name: "select", arguments: [.basic((
             osx.map { [":\(SelectCase.osx.rawValue)": $0] } <+>
             watchos.map { [":\(SelectCase.watchos.rawValue)": $0] } <+>
             tvos.map { [":\(SelectCase.tvos.rawValue)": $0] } <+>
-            // TODO: Change to T.empty and move ios up when we support other platforms
-	        [SelectCase.fallback.rawValue: ios ?? T.empty ] ?? [:]
+	        iosSupport ?? [:]
         ).toStarlark())])
     }
 }


### PR DESCRIPTION
- break a long expression into smaller expressions
- fix the error: the compiler is unable to type-check this expression in reasonable time; try breaking up the expression into distinct sub-expressions

When my team upgraded to XCode 15.3 (Swift 5.10). they got the error

```
Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
external/bazelpods/Sources/BazelPodsCore/Core/MultiPlatform.swift:108:16: error: the compiler is unable to type-check this expression in reasonable time; try breaking up the expression into distinct sub-expressions
        return .functionCall(name: "select", arguments: [.basic((
               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
error: fatalError
Target @bazelpods//:bazelpods failed to build
```

I followed this stuff https://sarunw.com/posts/how-to-fix-the-compiler-is-unable-to-type-check-this-expression-in-reasonable-time/ and broke the long-expression to smaller.