### PR TITLE
fix: copy xcdatamodeld resources

### DIFF
--- a/Sources/BazelPodsCore/Analyzer/Analyzers/ResourcesAnalyzer.swift
+++ b/Sources/BazelPodsCore/Analyzer/Analyzers/ResourcesAnalyzer.swift
@@ -86,6 +86,7 @@ struct ResourcesAnalyzer<S: ResourcesRepresentable> {
                     if let last = components.last {
                         var fixed = last
                             .replacingOccurrences(of: "xcassets", with: "xcassets/**")
+                            .replacingOccurrences(of: "xcdatamodeld", with: "xcdatamodeld/**")
                         //                    .replacingOccurrences(of: "lproj", with: "lproj")
                         if fixed.isEmpty || fixed == "*" {
                             fixed = "**"

--- a/TestTools/Pods.json
+++ b/TestTools/Pods.json
@@ -568,6 +568,9 @@
     "SuperPlayer": {
       "version": "3.7.7"
     },
+    "SuperwallKit": {
+      "version": "3.7.0"
+    },
     "SwiftCSV": {
       "version": "0.9.1"
     },

--- a/TestTools/Pods_Integration.json
+++ b/TestTools/Pods_Integration.json
@@ -236,6 +236,9 @@
         "SwiftyJSON": {
             "version": "5.0.1"
         },
+        "SuperwallKit": {
+          "version": "3.7.0"
+        },
         "Yoga": {
             "version": "1.14.0"
         },

--- a/Tests/Recorded/CoreStore/BUILD.bazel
+++ b/Tests/Recorded/CoreStore/BUILD.bazel
@@ -154,7 +154,7 @@ ios_unit_test(
   data = glob(
     [
       "CoreStoreTests/**/*.xcdatamodel",
-      "CoreStoreTests/**/*.xcdatamodeld"
+      "CoreStoreTests/**/*.xcdatamodeld/**"
     ]
   ),
   deps = [

--- a/Tests/Recorded/StreamChat/BUILD.bazel
+++ b/Tests/Recorded/StreamChat/BUILD.bazel
@@ -80,7 +80,7 @@ precompiled_apple_resource_bundle(
   ],
   resources = glob(
     [
-      "Sources/StreamChat/**/*.xcdatamodeld"
+      "Sources/StreamChat/**/*.xcdatamodeld/**"
     ]
   )
 )


### PR DESCRIPTION
Our team is integrating the SuperwallKit, which uses Core Data and requires copying resource models. The current BazelPods version doesn't support this, causing an issue. Posted about it here: https://github.com/superwall/Superwall-iOS/issues/228